### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
   def index
-    @items = Item.includes(:order).with_attached_image.order("created_at DESC")
+    @items = Item.includes(:order).with_attached_image.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.includes(:order).with_attached_image.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
   def index
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :shipment
   belongs_to :user
+  has_one :order
   has_one_attached :image
 
   with_options presence: true do

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,2 @@
+class Order < ApplicationRecord
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,4 @@
 class Order < ApplicationRecord
-	belongs_to :user
-	belongs_to :item
+  belongs_to :user
+  belongs_to :item
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,4 @@
 class Order < ApplicationRecord
+	belongs_to :user
+	belongs_to :item
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
   with_options presence: true do
     validates :nickname

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,55 +127,35 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to item_path(item) do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
+              <%# 商品が売れていればsold outの表示 %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outの表示 %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
     </ul>
   </div>
   <%# //商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,9 +134,11 @@
               <%= image_tag item.image, class: "item-img" %>
 
               <%# 商品が売れていればsold outの表示 %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
+              <% unless item.order.nil? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
               <%# //商品が売れていればsold outの表示 %>
 
             </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,20 +126,17 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
         <li class='list'>
           <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
-              <%# 商品が売れていればsold outの表示 %>
               <% unless item.order.nil? %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>
                 </div>
               <% end %>
-              <%# //商品が売れていればsold outの表示 %>
 
             </div>
             <div class='item-info'>

--- a/db/migrate/20200804034312_create_orders.rb
+++ b/db/migrate/20200804034312_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null:false, foreign_key: true
+      t.references :item, null:false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_002859) do
+ActiveRecord::Schema.define(version: 2020_08_04_034312) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_08_03_002859) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_08_03_002859) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     delivery_fee_id { 2 }
     prefecture_id { 2 }
     shipment_id { 2 }
+    image { Rack::Test::UploadedFile.new('public/images/test_image.jpg')}
     association :user
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :order do
-    
+    association :user
+    association :item
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'Items', type: :system do
       FactoryBot.create(:order, item: @item, user: @user)
     end
 
-    it 'orderが紐づいているitemにはSoldOutが付与されている' do
-      sign_in(@user)
+    it 'ログアウト状態でもorderが紐づいているitemにはSoldOutが付与されている' do
+      visit root_path
       expect(current_path).to eq root_path
       within('.item-lists') do
         expect(page).to have_content @item.price

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -39,20 +39,20 @@ RSpec.describe 'Items', type: :system do
     end
   end
 
-  describe "商品一覧表示" do
+  describe '商品一覧表示' do
     before do
       @item = FactoryBot.create(:item, image: fixture_file_upload('public/images/test_image.jpg'))
-      order = FactoryBot.create(:order, item: @item, user: @user)
+      FactoryBot.create(:order, item: @item, user: @user)
     end
 
-    it "orderが紐づいているitemにはSoldOutが付与されている" do
+    it 'orderが紐づいているitemにはSoldOutが付与されている' do
       sign_in(@user)
       expect(current_path).to eq root_path
-      within(".item-lists") do
+      within('.item-lists') do
         expect(page).to have_content @item.price
         expect(page).to have_content @item.name
         expect(page).to have_selector("img[src$='test_image.jpg']")
-        expect(page).to have_css(".sold-out")
+        expect(page).to have_css('.sold-out')
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -41,16 +41,15 @@ RSpec.describe 'Items', type: :system do
 
   describe '商品一覧表示' do
     before do
-      @item = FactoryBot.create(:item, image: fixture_file_upload('public/images/test_image.jpg'))
-      FactoryBot.create(:order, item: @item, user: @user)
+      @order = FactoryBot.create(:order)
     end
 
     it 'ログアウト状態でもorderが紐づいているitemにはSoldOutが付与されている' do
       visit root_path
       expect(current_path).to eq root_path
       within('.item-lists') do
-        expect(page).to have_content @item.price
-        expect(page).to have_content @item.name
+        expect(page).to have_content @order.item.price
+        expect(page).to have_content @order.item.name
         expect(page).to have_selector("img[src$='test_image.jpg']")
         expect(page).to have_css('.sold-out')
       end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe 'Items', type: :system do
       end
     end
   end
+
+  describe "商品一覧表示" do
+    before do
+      @item = FactoryBot.create(:item, image: fixture_file_upload('public/images/test_image.jpg'))
+      order = FactoryBot.create(:order, item: @item, user: @user)
+    end
+
+    it "orderが紐づいているitemにはSoldOutが付与されている" do
+      sign_in(@user)
+      expect(current_path).to eq root_path
+      within(".item-lists") do
+        expect(page).to have_content @item.price
+        expect(page).to have_content @item.name
+        expect(page).to have_selector("img[src$='test_image.jpg']")
+        expect(page).to have_css(".sold-out")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
- トップページに商品の画像/名前/価格が新規投稿順に表示される
- orderテーブルをREADMEにしたがって作成。関連するアソシエーションを定義しました。
- 購入が確定した商品はsold outが表示されるように実装しました
- 簡単な結合テストを実装しました。

# Why
- 購入が確定したかの有無について、itemに紐づくorderテーブルが存在するかどうかで判断しています。
- 結合テストは、紐づくorderテーブルが存在する場合に、sold outが表示されるのか確認するテストのみです。それ以上に確認するものがありませんでした。

# 動作確認
- [ログイン状態で商品が表示されている](https://gyazo.com/01564d41cf6f82c1470d2a02bdc1a63f)
- [新規商品を出品すると、右端に表示される](https://gyazo.com/8461ee117e3d5b662ead89caeb87eb69)
- [ログアウト状態でも商品が表示される](https://gyazo.com/2c84690b7fe0faf814b69777d4d07c90)
- [手動で先ほど出品した商品を購入状態にする](https://gyazo.com/2d8745655fa743e98c1b8556a69ee47a)
- [出品した商品にSold Outが付与される](https://gyazo.com/443b0c97a7054cfc32ebe92ee57feacf)
- [rubocopとrspecがグリーンである](https://gyazo.com/69ab78d47d2318229b9110f89bcd4fb9)