### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
+  before_action :set_item, only: [:show]
   def index
     @items = Item.includes(:order).with_attached_image.order('created_at DESC')
   end
@@ -18,7 +19,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private
@@ -32,5 +32,9 @@ class ItemsController < ApplicationController
 
   def logged_in_user?
     return redirect_to new_user_session_path unless user_signed_in?
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,19 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% unless @item.order.nil? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -36,33 +36,33 @@
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.genre.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipment.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,18 +22,16 @@
         (税込) 送料込み
       </span>
     </div>
-
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    
+    <% if user_signed_in? && current_user == @item.user %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+      <% if @item.order.nil? %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     delivery_fee_id { 2 }
     prefecture_id { 2 }
     shipment_id { 2 }
-    image { Rack::Test::UploadedFile.new('public/images/test_image.jpg')}
+    image { Rack::Test::UploadedFile.new('public/images/test_image.jpg') }
     association :user
   end
 end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Items', type: :system do
-  let(:user) {FactoryBot.create(:user)}
-  let!(:order) {FactoryBot.create(:order)}
+  let(:user) { FactoryBot.create(:user) }
+  let!(:order) { FactoryBot.create(:order) }
 
   describe '商品出品機能' do
     before do
@@ -51,9 +51,8 @@ RSpec.describe 'Items', type: :system do
     end
   end
 
-  describe "商品詳細表示" do
-
-    it "商品の詳細情報が表示されている" do
+  describe '商品詳細表示' do
+    it '商品の詳細情報が表示されている' do
       visit item_path(order.item)
       expect(page).to have_content order.item.price
       expect(page).to have_content order.item.name
@@ -67,29 +66,29 @@ RSpec.describe 'Items', type: :system do
       expect(page).to have_content order.item.shipment.name
     end
 
-    context "ログアウト状態の時" do
-      it "削除、編集ページへのリンクは表示されない" do
+    context 'ログアウト状態の時' do
+      it '削除、編集ページへのリンクは表示されない' do
         visit item_path(order.item)
-        expect(page).not_to have_content "商品の編集"
-        expect(page).not_to have_content "削除"
+        expect(page).not_to have_content '商品の編集'
+        expect(page).not_to have_content '削除'
       end
     end
-    context "ログイン状態の時" do
-      let(:another_user) {FactoryBot.create(:user)}
-      let(:item) {FactoryBot.create(:item)}
-      
-      it "出品したユーザーでないなら、削除、編集ページへのリンクは表示されない" do
+    context 'ログイン状態の時' do
+      let(:another_user) { FactoryBot.create(:user) }
+      let(:item) { FactoryBot.create(:item) }
+
+      it '出品したユーザーでないなら、削除、編集ページへのリンクは表示されない' do
         sign_in(another_user)
         visit item_path(order.item)
-        expect(page).not_to have_content "商品の編集"
-        expect(page).not_to have_content "削除"
+        expect(page).not_to have_content '商品の編集'
+        expect(page).not_to have_content '削除'
       end
 
-      it "出品したユーザーなら、削除、編集ページへのリンクが表示される" do
+      it '出品したユーザーなら、削除、編集ページへのリンクが表示される' do
         sign_in(item.user)
         visit item_path(item)
-        expect(page).to have_content "商品の編集"
-        expect(page).to have_content "削除"
+        expect(page).to have_content '商品の編集'
+        expect(page).to have_content '削除'
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Items', type: :system do
-  before do
-    @user = FactoryBot.create(:user)
-  end
+  let(:user) {FactoryBot.create(:user)}
+  let!(:order) {FactoryBot.create(:order)}
 
   describe '商品出品機能' do
+    before do
+      sign_in(user)
+      visit new_item_path
+    end
     context '出品が失敗した時' do
       it '送る値が空のため、メッセージの送信に失敗する' do
-        sign_in(@user)
-        visit new_item_path
         expect do
           find("input[name='commit']").click
         end.to change { Item.count }.by(0)
@@ -19,8 +20,6 @@ RSpec.describe 'Items', type: :system do
 
     context '出品が成功した時' do
       it '出品に成功するとトップページへ遷移する' do
-        sign_in(@user)
-        visit new_item_path
         image_path = Rails.root.join('public/images/test_image.jpg')
         attach_file('item[image]', image_path)
         fill_in 'item_name', with: '商品名'
@@ -40,18 +39,57 @@ RSpec.describe 'Items', type: :system do
   end
 
   describe '商品一覧表示' do
-    before do
-      @order = FactoryBot.create(:order)
-    end
-
     it 'ログアウト状態でもorderが紐づいているitemにはSoldOutが付与されている' do
       visit root_path
       expect(current_path).to eq root_path
       within('.item-lists') do
-        expect(page).to have_content @order.item.price
-        expect(page).to have_content @order.item.name
+        expect(page).to have_content order.item.price
+        expect(page).to have_content order.item.name
         expect(page).to have_selector("img[src$='test_image.jpg']")
         expect(page).to have_css('.sold-out')
+      end
+    end
+  end
+
+  describe "商品詳細表示" do
+
+    it "商品の詳細情報が表示されている" do
+      visit item_path(order.item)
+      expect(page).to have_content order.item.price
+      expect(page).to have_content order.item.name
+      expect(page).to have_selector("img[src$='test_image.jpg']")
+      expect(page).to have_content order.item.description
+      expect(page).to have_content order.item.user.nickname
+      expect(page).to have_content order.item.genre.name
+      expect(page).to have_content order.item.status.name
+      expect(page).to have_content order.item.delivery_fee.name
+      expect(page).to have_content order.item.prefecture.name
+      expect(page).to have_content order.item.shipment.name
+    end
+
+    context "ログアウト状態の時" do
+      it "削除、編集ページへのリンクは表示されない" do
+        visit item_path(order.item)
+        expect(page).not_to have_content "商品の編集"
+        expect(page).not_to have_content "削除"
+      end
+    end
+    context "ログイン状態の時" do
+      let(:another_user) {FactoryBot.create(:user)}
+      let(:item) {FactoryBot.create(:item)}
+      
+      it "出品したユーザーでないなら、削除、編集ページへのリンクは表示されない" do
+        sign_in(another_user)
+        visit item_path(order.item)
+        expect(page).not_to have_content "商品の編集"
+        expect(page).not_to have_content "削除"
+      end
+
+      it "出品したユーザーなら、削除、編集ページへのリンクが表示される" do
+        sign_in(item.user)
+        visit item_path(item)
+        expect(page).to have_content "商品の編集"
+        expect(page).to have_content "削除"
       end
     end
   end


### PR DESCRIPTION
# What
- トップページの商品をクリックすると詳細ページへ行けるようにリンクを貼りました。
- ログインしていなければ、購入画面のボタンが表示されます
- ログインしているユーザーが出品者でないなら、購入画面のボタンが表示されます
- ログインしているユーザーが出品者であるなら、編集と削除のボタンが表示されます
- 詳細ページの結合テストを作成しました。
- rspecのインスタンス変数を、letに書き換えました

# Why
- 現状、リンクは全て#にしています。各機能実装時に正しいリンクを貼ります
- rspecの情報を調べた時に、letを使用することを推奨していたので記述を変更しました。
- 結合テストは以下のように作成しました。
```
商品の詳細情報が表示されている
ログアウト状態の時
 削除、編集ページへのリンクは表示されない
ログイン状態の時
 出品したユーザーでないなら、削除、編集ページへのリンクは表示されない
 出品したユーザーなら、削除、編集ページへのリンクが表示される
```
- 結合テストの「出品したユーザーなら、削除、編集ページへのリンクが表示される」の部分について、これは狙ってこのように記述しました。
>理由として、当初order.item.userにuserを代入していたのですが、それだとエラーになってしまいました。推測ですが、原因はlet!で先にorderを作成し、その後にorder.itemと紐づいているuserを手動でかえる行為をrailsはAssociationの値を変えることを許容していないからなのではないかと思います。
>なので、このテストに限りitemを作成し、自動生成されたitem.userでログインしてリンクの有無を確認する仕様にしました。

# 動作確認
- [ログアウトしている](https://gyazo.com/bd26d38610548e2a684dece05e14cc19)
- [購入画面へ進むのみ表示される](https://gyazo.com/694f87662fcec06f58a0783b22d74ae6)
- [SoldOutしていたら、何も表示されない](https://gyazo.com/5f3183b284ad5d7ca6166b3a490f2dd9)
- [出品していないユーザーでログイン](https://gyazo.com/194a5062a5e550a05e9866441d794fce)
- [購入画面へ進むのみ表示される](https://gyazo.com/32a89c9fca1e548d4f1fa783e0a31005)
- [SoldOutしていたら、何も表示されない](https://gyazo.com/748e4d956c0a10aa61bdc3aca12db6b0)
- [出品したユーザーでログイン](https://gyazo.com/81c16ea724eb4340e67b0ab7c1f15b50)
- [編集・削除が表示される](https://gyazo.com/09276d0284a949333d8b06f0b864a6cb)
- [rubocop、rspecがグリーン](https://gyazo.com/e69245f9cb0295ef5d0a11840fa24e4f)

