### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_user?, only: [:edit, :destroy]
-  before_action :sold_out?, only: [:edit, :update, :destroy]
+  before_action :sold_out?, only: [:edit, :update]
   def index
     @items = Item.includes(:order).with_attached_image.order('created_at DESC')
   end
@@ -35,8 +35,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :item_user?, only: [:edit]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :item_user?, only: [:edit, :destroy]
   before_action :sold_out?, only: [:edit, :update]
   def index
     @items = Item.includes(:order).with_attached_image.order('created_at DESC')
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render 'edit'
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :logged_in_user?, only: [:new, :create]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_user?, only: [:edit, :destroy]
-  before_action :sold_out?, only: [:edit, :update]
+  before_action :sold_out?, only: [:edit, :update, :destroy]
   def index
     @items = Item.includes(:order).with_attached_image.order('created_at DESC')
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
+  before_destroy :should_not_destroy
   belongs_to_active_hash :genre
   belongs_to_active_hash :status
   belongs_to_active_hash :delivery_fee
@@ -19,5 +20,11 @@ class Item < ApplicationRecord
     validates :delivery_fee_id, numericality: { other_than: 1 }
     validates :prefecture_id, numericality: { other_than: 1 }
     validates :shipment_id, numericality: { other_than: 1 }
+  end
+
+  private
+
+  def should_not_destroy
+    return throw :abort unless order.nil?
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user == @item.user %>
       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <% elsif @item.order.nil? %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -131,4 +131,26 @@ RSpec.describe 'Items', type: :system do
       end
     end
   end
+
+  describe '商品削除機能' do
+    let(:item) { FactoryBot.create(:item) }
+    context '削除に失敗した時' do
+      it '出品者でないユーザーでは削除できず、トップページへ遷移する' do
+        sign_in(user)
+        visit item_path(item)
+        expect(page).to have_no_link "削除", href: item_path(item)
+      end
+    end
+    context '削除に成功した時' do
+      it '出品者であるなら削除に成功し、トップページへ遷移する' do
+        sign_in(item.user)
+        visit item_path(item)
+        expect  do
+          find_link('削除', href: item_path(item)).click
+        end.to change { Item.count }.by(-1)
+        expect(current_path).to eq root_path
+        expect(page).to have_no_content item.name
+      end
+    end
+  end
 end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe 'Items', type: :system do
         visit item_path(item)
         expect(page).to have_no_link '削除', href: item_path(item)
       end
+      it '購入済みだと削除できず、トップページへ遷移する' do
+        sign_in(order.item.user)
+        visit item_path(order.item)
+        expect do
+          find_link('削除', href: item_path(order.item)).click
+        end.to change { Item.count }.by(0)
+        expect(current_path).to eq root_path
+        expect(page).to have_link order.item.name, href: item_path(order.item)
+      end
     end
     context '削除に成功した時' do
       it '出品者であるなら削除に成功し、トップページへ遷移する' do
@@ -149,7 +158,7 @@ RSpec.describe 'Items', type: :system do
           find_link('削除', href: item_path(item)).click
         end.to change { Item.count }.by(-1)
         expect(current_path).to eq root_path
-        expect(page).to have_no_content item.name
+        expect(page).to have_no_link item.name, href: item_path(item)
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Items', type: :system do
   describe '商品削除機能' do
     let(:item) { FactoryBot.create(:item) }
     context '削除に失敗した時' do
-      it '出品者でないユーザーでは削除できず、トップページへ遷移する' do
+      it '出品者でないと削除リンクが存在しない' do
         sign_in(user)
         visit item_path(item)
         expect(page).to have_no_link '削除', href: item_path(item)

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -138,14 +138,14 @@ RSpec.describe 'Items', type: :system do
       it '出品者でないユーザーでは削除できず、トップページへ遷移する' do
         sign_in(user)
         visit item_path(item)
-        expect(page).to have_no_link "削除", href: item_path(item)
+        expect(page).to have_no_link '削除', href: item_path(item)
       end
     end
     context '削除に成功した時' do
       it '出品者であるなら削除に成功し、トップページへ遷移する' do
         sign_in(item.user)
         visit item_path(item)
-        expect  do
+        expect do
           find_link('削除', href: item_path(item)).click
         end.to change { Item.count }.by(-1)
         expect(current_path).to eq root_path

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe 'Items', type: :system do
         expect do
           find_link('削除', href: item_path(order.item)).click
         end.to change { Item.count }.by(0)
-        expect(current_path).to eq root_path
-        expect(page).to have_link order.item.name, href: item_path(order.item)
+        expect(current_path).to eq item_path(order.item)
       end
     end
     context '削除に成功した時' do


### PR DESCRIPTION
# What
- 詳細ページの削除ボタンにリンクを張りました。
- 出品者出ないと詳細ページに削除ボタンが表示されないようになっています
- destroyアクションを実行する時に、出品者であることを確認するようにしました
- 結合テストを作りました。

# Why
- 今回は購入済みでも削除は可能にしました。削除できなくても良いかなと思ったのですが、判別がつかなかったので暫定的に削除可能にしています。
- 結合テストは以下のように作成しました。
```
削除に失敗した時
 出品者でないと削除リンクが存在しない
削除に成功した時
 出品者であるなら削除に成功し、トップページへ遷移する
```

# 動作確認
- [出品者でないなら、削除ボタンが存在しない](https://gyazo.com/616862de3e2b5453a85a5f31132fc926)
- [出品者であるなら削除ボタンが存在する](https://gyazo.com/8da0e6376a7b50fa6c2121fe87405c5c)
- [Sold OUtの商品は削除できず、トップページへ遷移する](https://gyazo.com/61e8107dc06c40744afa20d4362c73e4)
- [未購入の商品を削除する](https://gyazo.com/8bbef99ddc0042074fe48f56969a3279)
- [トップページに遷移し、削除できている](https://gyazo.com/79195ad9fb23143a1ae9ebe76f0317f0)
- [DBからも削除できている](https://gyazo.com/e0abb7ab2a781e60a892b143497e2ba5)
- [rubocopとrspecがグリーンである](https://gyazo.com/6e887ca1342431f5d698c31101e3fae5)